### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/id.js
+++ b/lib/id.js
@@ -27,7 +27,7 @@
 var crypto = require('crypto');
 var path = require('path');
 var url = require('url');
-var node_uuid = require('node-uuid');
+var node_uuid = require('uuid');
 
 var _ = require("../helpers");
 

--- a/package.json
+++ b/package.json
@@ -1,43 +1,43 @@
 {
-    "author": "David P. Janes <davidjanes@iotdb.org> (https://iotdb.org)", 
-    "bugs": {
-        "url": "https://github.com/dpjanes/iotdb-helpers/issues"
-    }, 
-    "dependencies": {
-        "assert": "~1.4.1", 
-        "bunyan": "~1.8.4", 
-        "crypto": "~0.0.3", 
-        "iotdb-helpers": "~3.0.15", 
-        "node-uuid": "~1.4.7", 
-        "underscore": "~1.8.3", 
-        "unirest": "~0.5.1", 
-        "url-join": "~1.1.0"
-    }, 
-    "description": "IOTDB Module", 
-    "devDependencies": {
-        "grunt": "~1.0.1", 
-        "grunt-contrib-jshint": "~1.0.0", 
-        "grunt-contrib-nodeunit": "~1.0.0", 
-        "grunt-contrib-uglify": "~2.0.0", 
-        "grunt-contrib-watch": "~1.0.0", 
-        "grunt-jsbeautifier": "~0.2.13", 
-        "jshint-stylish": "~2.2.1", 
-        "load-grunt-tasks": "~3.5.2", 
-        "request": "~2.76.0"
-    }, 
-    "homepage": "https://github.com/dpjanes/node-iotdb",
-    "iotdb": {}, 
-    "license": "Apache-2.0", 
-    "main": "helpers.js", 
-    "name": "iotdb-helpers", 
-    "private": false, 
-    "repository": {
-        "type": "git", 
-        "url": "https://github.com/dpjanes/iotdb-helpers"
-    }, 
-    "scripts": {
-        "cover": "istanbul cover _mocha test", 
-        "test": "grunt"
-    }, 
-    "version": "3.0.16"
+  "author": "David P. Janes <davidjanes@iotdb.org> (https://iotdb.org)",
+  "bugs": {
+    "url": "https://github.com/dpjanes/iotdb-helpers/issues"
+  },
+  "dependencies": {
+    "assert": "~1.4.1",
+    "bunyan": "~1.8.4",
+    "crypto": "~0.0.3",
+    "iotdb-helpers": "~3.0.15",
+    "underscore": "~1.8.3",
+    "unirest": "~0.5.1",
+    "url-join": "~1.1.0",
+    "uuid": "^3.0.0"
+  },
+  "description": "IOTDB Module",
+  "devDependencies": {
+    "grunt": "~1.0.1",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt-contrib-uglify": "~2.0.0",
+    "grunt-contrib-watch": "~1.0.0",
+    "grunt-jsbeautifier": "~0.2.13",
+    "jshint-stylish": "~2.2.1",
+    "load-grunt-tasks": "~3.5.2",
+    "request": "~2.76.0"
+  },
+  "homepage": "https://github.com/dpjanes/node-iotdb",
+  "iotdb": {},
+  "license": "Apache-2.0",
+  "main": "helpers.js",
+  "name": "iotdb-helpers",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/dpjanes/iotdb-helpers"
+  },
+  "scripts": {
+    "cover": "istanbul cover _mocha test",
+    "test": "grunt"
+  },
+  "version": "3.0.16"
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.